### PR TITLE
Updated Cron examples for scheduled tasks

### DIFF
--- a/docs/02.devguides/29.taskmanager/predefinedtasks/page.md
+++ b/docs/02.devguides/29.taskmanager/predefinedtasks/page.md
@@ -70,7 +70,7 @@ Some example cron definitions:
  * @schedule 0 25 *\/2 * * *
  *
  * At 4:06 AM, only on Tuesday
- * @schedule 0 06 04 * * Tue
+ * @schedule 0 06 04 * * 2
  */
 ```
 


### PR DESCRIPTION
I think there is a minor issue as the example does not match the cron definition mentioned above.
It states 'Tue' for the day which should probably be '2' according to the definition.