### PR TITLE
Update placeholder image name in developer guides' widgets

### DIFF
--- a/docs/02.devguides/31.widgets/page.md
+++ b/docs/02.devguides/31.widgets/page.md
@@ -9,7 +9,7 @@ One of Preside's most powerful and easy to build features is its widget framewor
 
 ![Screenshot showing widget configurator](images/screenshots/widgetConfiguration.jpg)
 
-![Screenshot showing widget placeholders](images/screenshots/widgetPlaceholders.jpg)
+![Screenshot showing widget placeholders](images/screenshots/widgetplaceholders.jpg)
 
 
 ## Creating a new widget


### PR DESCRIPTION
Update placeholder image name in developer guides' widgets to fix the broken image link.