### PR TITLE
fixed wrong return type in example

### DIFF
--- a/docs/02.devguides/40.datamanager/customization/getExtraListingMultiActions/page.md
+++ b/docs/02.devguides/40.datamanager/customization/getExtraListingMultiActions/page.md
@@ -22,7 +22,7 @@ For example:
 // /application/handlers/admin/datamanager/GlobalDefaults.cfc
 component {
 
-    private array function getExtraListingMultiActions( event, rc, prc, args={} ) {
+    private void function getExtraListingMultiActions( event, rc, prc, args={} ) {
         args.actions = args.actions ?: [];
         args.actions.append( {
               label     = "Archive selected entities"


### PR DESCRIPTION
fixed wrong return type in getExtraListingMultiActions data manager customisation example. It's supposed to return nothing and not an array.