### PR TITLE
Added details on using aliasses in selectData

### DIFF
--- a/docs/02.devguides/02.dataobjects/page.md
+++ b/docs/02.devguides/02.dataobjects/page.md
@@ -685,7 +685,7 @@ In addition to the four core methods above, there are also further utility metho
 
 #### Specifying fields for selection
 
-The [[presideobjectservice-selectdata]] method accepts a `selectFields` argument that can be used to specify which fields you wish to select. This can be used to select properties on your object as well as properties on related objects and any plain SQL aggregates or other SQL operations. For example:
+The [[presideobjectservice-selectdata]] method accepts a `selectFields` argument that can be used to specify which fields you wish to select. This can be done by the field's name or one of it's aliasses. This can be used to select properties on your object as well as properties on related objects and any plain SQL aggregates or other SQL operations. For example:
 
 ```luceescript
 records = newsObject.selectData(


### PR DESCRIPTION
I've added a sentence to specify that when using selectData, you can use both property name as well as an alias for the property in the selecteFields array.